### PR TITLE
Acrescentado dos do usuário do fornecedor (supplier) no retorno das propostas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ group :test do
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "ed25519", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     doorkeeper (5.0.0.rc2)
       railties (>= 4.2)
     dry-inflector (0.1.2)
+    ed25519 (1.2.4)
     erubi (1.7.1)
     excon (0.62.0)
     factory_bot (4.10.0)
@@ -613,6 +614,7 @@ DEPENDENCIES
   deep_cloneable
   devise
   doorkeeper (~> 5.0.0.rc2)
+  ed25519 (~> 1.2)
   extensobr!
   factory_bot_rails
   faraday-cookie_jar

--- a/app/serializers/administrator/lot_proposal_serializer.rb
+++ b/app/serializers/administrator/lot_proposal_serializer.rb
@@ -2,7 +2,7 @@ module Administrator
   class LotProposalSerializer < ActiveModel::Serializer
     include CurrentEventProposable
 
-    attributes :lot
+    attributes :lot, :suppliers
 
     has_many :lot_group_item_lot_proposals, serializer: Administrator::LotGroupItemLotProposalSerializer
 
@@ -20,6 +20,10 @@ module Administrator
 
     def bidding_title
       object.lot.bidding.title
+    end
+
+    def suppliers
+      object.proposal.provider.suppliers.as_json
     end
 
     private

--- a/app/serializers/coop/lot_proposal_serializer.rb
+++ b/app/serializers/coop/lot_proposal_serializer.rb
@@ -1,7 +1,8 @@
 module Coop
   class LotProposalSerializer < ActiveModel::Serializer
     attributes :id, :proposal_id, :status, :bidding_id, :bidding_title,
-                :price_total, :delivery_price, :current, :lot, :provider
+                :price_total, :delivery_price, :current, :lot, :provider, 
+                :suppliers
 
     has_many :lot_group_item_lot_proposals, serializer: Supp::LotGroupItemLotProposalSerializer
 
@@ -23,6 +24,10 @@ module Coop
 
     def provider
       proposal.provider.as_json
+    end
+
+    def suppliers
+      proposal.provider.suppliers.as_json
     end
 
     def bidding_id


### PR DESCRIPTION
Foi solicitada a inclusão dos dados de contato do fornecedor durante a exibição da proposta vencedora. Assim, foi adicionado o método supplier em lot_proposal_serializer.rb dos módulos associação e administrador.

O frontend também foi atualizado. Conforme imagem a seguir:

<img width="405" alt="Captura de Tela 2019-12-02 às 15 28 06" src="https://user-images.githubusercontent.com/1784213/70055379-2f4d9200-15b8-11ea-835f-755407dbf9e8.png">
