### PR TITLE
[Bug] Correção da exibição das notificações do Revisor em produção

### DIFF
--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -11,6 +11,8 @@ class NotificationSerializer < ActiveModel::Serializer
   end
 
   def body
+    return I18n.t('notifications.common_messages.body_error') unless object.body_args
+
     I18n.t("#{key}.body") % object.body_args
   end
 

--- a/config/locales/notifications/commom_messages.pt-BR.yml
+++ b/config/locales/notifications/commom_messages.pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  notifications:
+    common_messages:
+      body_error: >
+        Houve um erro ao exibir a mensagem da notificação.

--- a/config/locales/notifications/common_messages.en-US.yml
+++ b/config/locales/notifications/common_messages.en-US.yml
@@ -1,0 +1,6 @@
+pt-BR:
+  notifications:
+    common_messages:
+      body_error: >
+        There was an error displaying the notification message.
+

--- a/config/locales/notifications/common_messages.es-PY.yml
+++ b/config/locales/notifications/common_messages.es-PY.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  notifications:
+    common_messages:
+      body_error: >
+        Hubo un error al mostrar el mensaje de notificación.

--- a/config/locales/notifications/common_messages.fr-FR.yml
+++ b/config/locales/notifications/common_messages.fr-FR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  notifications:
+    common_messages:
+      body_error: >
+        Une erreur s'est produite lors de l'affichage du message de notification.

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe NotificationSerializer, type: :serializer do
-  let(:object) { create(:notification, read_at: DateTime.now) }
+  let(:object) { create(:notification, read_at: DateTime.now, data: { "body_args" => ['Mensagem'] }) }
 
   subject { format_json(described_class, object) }
 
@@ -17,5 +17,13 @@ RSpec.describe NotificationSerializer, type: :serializer do
     it { is_expected.to include 'body' => body }
     it { is_expected.to include 'notifiable_id' => object.notifiable_id }
     it { is_expected.to include 'args' => object.extra_args }
+
+    context 'When body_args are not present' do
+      let(:object) { create(:notification, read_at: DateTime.now, data: { "title_args" => ['Título'] }) }
+
+      subject { format_json(described_class, object) }
+
+      it { is_expected.to include 'body' => I18n.t('notifications.common_messages.body_error') }
+    end
   end
 end


### PR DESCRIPTION
- O banco de dados de produção possui dados de notificações sem argumentos causando erro 500 ao listar as notificações do revisor. Para corrigir esse problema, verifica-se se o parâmetro body_args está presente.

- Erro exibido no log em produção:

```
Notification Load (13.6ms)  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."id" IN (SELECT "notifications"."id" FROM "notifications" WHERE "notifications"."receivable_id" = $1 AND "notifications"."receivable_type" = $2) AND "notifications"."receivable_type" = $3 AND "notifications"."receivable_id" = $4 ORDER BY notifications.created_at desc LIMIT $5 OFFSET $6  [["receivable_id", 54], ["receivable_type", "Admin"], ["receivable_type", "Admin"], ["receivable_id", 54], ["LIMIT", 20], ["OFFSET", 0]]
I, [2021-11-30T15:37:12.342664 #12415]  INFO -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf] [active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (43.4ms)
I, [2021-11-30T15:37:12.344224 #12415]  INFO -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf] Completed 500 Internal Server Error in 146ms (ActiveRecord: 49.5ms)
F, [2021-11-30T15:37:12.351947 #12415] FATAL -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf]   
F, [2021-11-30T15:37:12.352502 #12415] FATAL -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf] ArgumentError (too few arguments):
F, [2021-11-30T15:37:12.352885 #12415] FATAL -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf]   
F, [2021-11-30T15:37:12.353172 #12415] FATAL -- : [b0e9f423-2585-4bce-bdb7-48b366ddd8cf] app/serializers/notification_serializer.rb:14:in `%'
[b0e9f423-2585-4bce-bdb7-48b366ddd8cf] app/serializers/notification_serializer.rb:14:in `body'
[b0e9f423-2585-4bce-bdb7-48b366ddd8cf] app/controllers/concerns/base_notifications_controller.rb:16:in `index'
I, [2021-11-30T15:37:14.973834 #4541]  INFO -- : [1491fcdf-5af5-4b78-a460-8a2c23fedab5] Started GET "/cooperative/notifications/unreads_count" for 10.70.0.254 at 2021-11-30 15:37:14 -0300
I, [2021-11-30T15:37:14.977165 #4541]  INFO -- : [1491fcdf-5af5-4b78-a460-8a2c23fedab5] Processing by Coop::NotificationsController#unreads_count as JSON

```