### PR TITLE
Refused contract bug master bahia

### DIFF
--- a/app/models/bidding.rb
+++ b/app/models/bidding.rb
@@ -155,7 +155,7 @@ class Bidding < ApplicationRecord
     proposals.
       joins(:lot_proposals).
       where(
-        status: %i[sent accepted refused],
+        status: %i[sent accepted],
         lot_proposals: { lot_id: lot_ids }
       )
   end

--- a/spec/models/bidding_spec.rb
+++ b/spec/models/bidding_spec.rb
@@ -607,7 +607,7 @@ RSpec.describe Bidding, type: :model do
         let!(:proposal_5) { create(:proposal, bidding: bidding, lot: lot_2, status: :sent) }
         let(:scope_params) { proposal_1.current_lot_ids }
 
-        it { is_expected.to match_array [proposal_2, proposal_3, proposal_4] }
+        it { is_expected.to match_array [proposal_2, proposal_3] }
       end
 
       context 'when the bidding kind is global' do
@@ -619,7 +619,7 @@ RSpec.describe Bidding, type: :model do
         let!(:proposal_5) { create(:proposal, bidding: bidding, status: :sent) }
         let(:scope_params) { bidding.lot_ids }
 
-        it { is_expected.to match_array [proposal_2, proposal_3, proposal_4, proposal_5] }
+        it { is_expected.to match_array [proposal_2, proposal_3, proposal_5] }
       end
     end
 
@@ -663,7 +663,7 @@ RSpec.describe Bidding, type: :model do
       end
     end
 
-    fdescribe '.fully_refused_proposals?' do
+    describe '.fully_refused_proposals?' do
       let!(:bidding)           { create(:bidding) }
       let(:refused_proposal_1) { create(:proposal, bidding: bidding, status: :refused) }
       let(:refused_proposal_2) { create(:proposal, bidding: bidding, status: :refused) }

--- a/spec/services/biddings_service/proposals/retry/global_spec.rb
+++ b/spec/services/biddings_service/proposals/retry/global_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BiddingsService::Proposals::Retry::Global, type: :service do
       it { expect(proposal_2.sent?).to be_truthy }
       it { expect(lot_2.triage?).to be_truthy }
       it { expect(proposal_3.triage?).to be_truthy }
-      it { expect(proposal_4.sent?).to be_truthy }
+      it { expect(proposal_4.sent?).to be_falsy }
     end
 
     context 'when return error' do


### PR DESCRIPTION
- Problema: Quando uma licitação era reaberta, o status de suas propostas eram atualizados para 'sent' mesmo se já haviam sido recusadas pela associação. Desse modo, a associação tinha que reprovar a proposta novamente. A correção implica na remoção do status 'refused' ao considerar as propostas que serão avaliadas. 

---

- Licitação com a primeira proposta recusada, a segunda aceita, porém o fornecedor recusou o contrato e a terceira disponível após a associação solicitar a reabertura da licitação:

![image](https://user-images.githubusercontent.com/8549327/145853537-a2ac3239-8fe3-457b-9a69-ff0168ed3e12.png)
