### PR TITLE
[Email] Bloquear o envio de e-mail para os fornecedores 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,6 @@ class User < ApplicationRecord
     dependent: :destroy
 
   has_many :device_tokens, as: :owner, dependent: :destroy
-  has_many :lot_answers, dependent: :restrict_with_error
 
   validates :name,
             :cpf,

--- a/app/services/notifications/base.rb
+++ b/app/services/notifications/base.rb
@@ -49,7 +49,10 @@ module Notifications
           ::Notifications::Fcm.delay.call(notification.id)
 
           # Envia e-mail junto com a notificação com o mesmo conteúdo.
-          ::NotificationMailer.notification_email(notification).deliver_later
+          # Email deve ser enviado apenas para usuários que não sejam fornecedores
+          # A interrupção do envio de e-mails para os fornecedores foi solicitada pelo cliente, pois
+          # foi constatado que os fornecedores estavam recebendo muitos e-mails. 
+          ::NotificationMailer.notification_email(notification).deliver_later unless receiver.is_a?(Supplier)
         end
       end
     end

--- a/spec/controllers/search/states_controller_spec.rb
+++ b/spec/controllers/search/states_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Search::StatesController, type: :controller do
       let(:json_response) { JSON.load(response.body).to_json }
       let(:result_arr) do 
         [
-          { id: states.first.id, text: states.first.text }, 
-          { id: states.second.id, text: states.second.text }
+          { id: states.first.id, text: states.first.name }, 
+          { id: states.second.id, text: states.second.name }
         ].to_json
       end
 

--- a/spec/mailers/notification_spec.rb
+++ b/spec/mailers/notification_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
   
     it 'renders the sender' do
-      expect(email.from).to eql(['nao-responda@car.ba.gov.br'])
+      expect(email.from).to eql(['no-reply@example.com'])
     end
 
     it 'renders body' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:access_tokens).dependent(:destroy) }
     it { is_expected.to have_many(:access_grants).dependent(:destroy) }
     it { is_expected.to have_many(:device_tokens).dependent(:destroy) }
-    it { is_expected.to have_many(:lot_answers).dependent(:restrict_with_error) }
 
     it { is_expected.to belong_to :cooperative }
     it { is_expected.to belong_to(:role).optional }

--- a/spec/services/notifications/biddings/additives/created_spec.rb
+++ b/spec/services/notifications/biddings/additives/created_spec.rb
@@ -100,6 +100,6 @@ require 'rails_helper'
 
      it_should_behave_like 'services/concerns/notifications/fcm', 4
 
-     it_should_behave_like 'services/concerns/notifications/notification_mailer', 4
+     it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/biddings/cancellation_requests/approved/provider_spec.rb
+++ b/spec/services/notifications/biddings/cancellation_requests/approved/provider_spec.rb
@@ -45,7 +45,5 @@ RSpec.describe Notifications::Biddings::CancellationRequests::Approved::Provider
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/draw/draw_provider_spec.rb
+++ b/spec/services/notifications/biddings/draw/draw_provider_spec.rb
@@ -39,7 +39,5 @@ RSpec.describe Notifications::Biddings::Draw::DrawProvider, type: [:service, :no
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/draw/sent_provider_spec.rb
+++ b/spec/services/notifications/biddings/draw/sent_provider_spec.rb
@@ -39,7 +39,5 @@ RSpec.describe Notifications::Biddings::Draw::SentProvider, type: [:service, :no
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/failure/all/provider_spec.rb
+++ b/spec/services/notifications/biddings/failure/all/provider_spec.rb
@@ -55,7 +55,5 @@ RSpec.describe Notifications::Biddings::Failure::All::Provider, type: [:service,
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/failure/provider_spec.rb
+++ b/spec/services/notifications/biddings/failure/provider_spec.rb
@@ -35,7 +35,5 @@ RSpec.describe Notifications::Biddings::Failure::Provider, type: [:service, :not
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/finished_spec.rb
+++ b/spec/services/notifications/biddings/finished_spec.rb
@@ -112,6 +112,6 @@ RSpec.describe Notifications::Biddings::Finished, type: [:service, :notification
 
     it_should_behave_like 'services/concerns/notifications/fcm', 4
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 4
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/biddings/ongoing/classification_provider_spec.rb
+++ b/spec/services/notifications/biddings/ongoing/classification_provider_spec.rb
@@ -82,8 +82,6 @@ RSpec.describe Notifications::Biddings::Ongoing::ClassificationProvider, type: [
       end
 
       it_should_behave_like 'services/concerns/notifications/fcm'
-
-      it_should_behave_like 'services/concerns/notifications/notification_mailer'
     end
   end
 end

--- a/spec/services/notifications/biddings/ongoing/invited_provider_spec.rb
+++ b/spec/services/notifications/biddings/ongoing/invited_provider_spec.rb
@@ -36,7 +36,5 @@ RSpec.describe Notifications::Biddings::Ongoing::InvitedProvider, type: [:servic
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/biddings/under_review/provider_spec.rb
+++ b/spec/services/notifications/biddings/under_review/provider_spec.rb
@@ -67,7 +67,5 @@ RSpec.describe Notifications::Biddings::UnderReview::Provider, type: [:service, 
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm', 2
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/contracts/completed_spec.rb
+++ b/spec/services/notifications/contracts/completed_spec.rb
@@ -127,6 +127,6 @@ RSpec.describe Notifications::Contracts::Completed, type: [:service, :notificati
 
     it_should_behave_like 'services/concerns/notifications/fcm', 3
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 3
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/contracts/created_spec.rb
+++ b/spec/services/notifications/contracts/created_spec.rb
@@ -92,6 +92,6 @@ RSpec.describe Notifications::Contracts::Created, type: [:service, :notification
 
     it_should_behave_like 'services/concerns/notifications/fcm', 2
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 1
   end
 end

--- a/spec/services/notifications/contracts/partial_execution_spec.rb
+++ b/spec/services/notifications/contracts/partial_execution_spec.rb
@@ -127,6 +127,6 @@ RSpec.describe Notifications::Contracts::PartialExecution, type: [:service, :not
 
     it_should_behave_like 'services/concerns/notifications/fcm', 3
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 3
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/contracts/refused/all_spec.rb
+++ b/spec/services/notifications/contracts/refused/all_spec.rb
@@ -126,6 +126,6 @@ RSpec.describe Notifications::Contracts::Refused::All, type: [:service, :notific
 
     it_should_behave_like 'services/concerns/notifications/fcm', 3
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 3
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/contracts/refused/user_spec.rb
+++ b/spec/services/notifications/contracts/refused/user_spec.rb
@@ -98,6 +98,6 @@ RSpec.describe Notifications::Contracts::Refused::User, type: [:service, :notifi
 
     it_should_behave_like 'services/concerns/notifications/fcm', 2
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 1
   end
 end

--- a/spec/services/notifications/contracts/supplier_signature/close_to_deadline_spec.rb
+++ b/spec/services/notifications/contracts/supplier_signature/close_to_deadline_spec.rb
@@ -66,7 +66,5 @@ RSpec.describe Notifications::Contracts::SupplierSignature::CloseToDeadline, typ
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm', 1
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 1
   end
 end

--- a/spec/services/notifications/contracts/supplier_signature/last_day_of_deadline_spec.rb
+++ b/spec/services/notifications/contracts/supplier_signature/last_day_of_deadline_spec.rb
@@ -66,7 +66,5 @@ RSpec.describe Notifications::Contracts::SupplierSignature::LastDayOfDeadline, t
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm', 1
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 1
   end
 end

--- a/spec/services/notifications/contracts/total_inexecution_spec.rb
+++ b/spec/services/notifications/contracts/total_inexecution_spec.rb
@@ -127,6 +127,6 @@ RSpec.describe Notifications::Contracts::TotalInexecution, type: [:service, :not
 
     it_should_behave_like 'services/concerns/notifications/fcm', 3
 
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 3
+    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/services/notifications/invites/approved_spec.rb
+++ b/spec/services/notifications/invites/approved_spec.rb
@@ -39,7 +39,5 @@ RSpec.describe Notifications::Invites::Approved, type: [:service, :notification]
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/invites/reproved_spec.rb
+++ b/spec/services/notifications/invites/reproved_spec.rb
@@ -40,7 +40,5 @@ RSpec.describe Notifications::Invites::Reproved, type: [:service, :notification]
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end

--- a/spec/services/notifications/proposals/suppliers/accepted_spec.rb
+++ b/spec/services/notifications/proposals/suppliers/accepted_spec.rb
@@ -88,7 +88,5 @@ RSpec.describe Notifications::Proposals::Suppliers::Accepted, type: [:service, :
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm', 2
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer', 2
   end
 end

--- a/spec/support/shared_examples/services/concerns/proposal_import_notification.rb
+++ b/spec/support/shared_examples/services/concerns/proposal_import_notification.rb
@@ -45,7 +45,5 @@ RSpec.shared_examples 'services/concerns/proposal_import_notification' do |type|
     end
 
     it_should_behave_like 'services/concerns/notifications/fcm'
-
-    it_should_behave_like 'services/concerns/notifications/notification_mailer'
   end
 end


### PR DESCRIPTION
- Foi bloqueado o envio de e-mail para todos os casos de notificações para os fornecedores
- Correção dos testes quebrados com o ajuste