### PR TITLE
[Bug] Correção da exibição do botão de concluir uma licitação

### DIFF
--- a/app/serializers/concerns/bidding_serializable.rb
+++ b/app/serializers/concerns/bidding_serializable.rb
@@ -90,7 +90,7 @@ module BiddingSerializable
   end
 
   def allowed_to_finish?
-    ( object.lots.pluck(:status) - ["accepted", "desert", "failure"]).empty?
+    ( object.lots.pluck(:status) - ["accepted", "desert", "failure", "canceled"]).empty?
   end
 
   def event_resource

--- a/app/services/biddings_service/refinish.rb
+++ b/app/services/biddings_service/refinish.rb
@@ -36,7 +36,7 @@ module BiddingsService
 
     def lots_include_valid_statuses?
       bidding.lots.map(&:status).all? do |status|
-        ['accepted', 'desert', 'failure'].include?(status)
+        ['accepted', 'desert', 'failure', 'canceled'].include?(status)
       end
     end
 

--- a/spec/services/biddings_service/refinish_spec.rb
+++ b/spec/services/biddings_service/refinish_spec.rb
@@ -243,6 +243,19 @@ RSpec.describe BiddingsService::Refinish, type: :service do
         it { expect(worker.jobs.size).to eq(0) }
         it { expect(report_worker.jobs.size).to eq(0) }
       end
+
+      context 'and bidding has a valid status' do
+        context 'and a lot is canceled' do
+          before do
+            bidding.reopened!
+            bidding.lots.first.canceled!
+            subject
+            bidding.reload
+          end
+
+          it { expect(bidding.finnished?).to be_truthy }
+        end
+      end
     end
   end
 

--- a/spec/support/shared_examples/serializers/concerns/bidding_serializer.rb
+++ b/spec/support/shared_examples/serializers/concerns/bidding_serializer.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples "a bidding_serializer" do
   describe 'attributes' do
     let(:can_finish) do
       (object.under_review? || object.reopened?) &&
-        (object.lots.pluck(:status) - ["accepted", "desert", "failure"]).empty?
+        (object.lots.pluck(:status) - ["accepted", "desert", "failure", "canceled"]).empty?
     end
 
     let(:supp_can_see) { object.finnished? }


### PR DESCRIPTION
Ao concluir uma licitação se um dos lotes estiver com o status "Cancelado" a plataforma não permitia que o botão de "Concluir licitação" aparecesse.

- A solução foi adicionar esse status nas regras de exibição e validação de encerramento de uma licitação reaberta