### PR TITLE
Adiciona mecanismo de fracassar licitação para o Administrador

### DIFF
--- a/app/controllers/administrator/biddings/fails_controller.rb
+++ b/app/controllers/administrator/biddings/fails_controller.rb
@@ -1,0 +1,33 @@
+module Administrator
+  class Biddings::FailsController < AdminController
+    load_and_authorize_resource :bidding, parent: false
+
+    expose :bidding
+
+    before_action :set_paper_trail_whodunnit
+
+    delegate :event, to: :admin_failure_service
+
+    def update
+      if admin_failure?
+        render status: :ok
+      else
+        render status: :unprocessable_entity, json: { errors: event&.errors_as_json }
+      end
+    end
+
+    private
+
+    def admin_failure?
+      admin_failure_service.call
+    end
+
+    def admin_failure_service
+      @admin_failure_service ||= BiddingsService::AdminFailure.new(
+        bidding: bidding,
+        creator: current_user,
+        comment: params[:comment]
+      )
+    end
+  end
+end

--- a/app/services/biddings_service/admin_failure.rb
+++ b/app/services/biddings_service/admin_failure.rb
@@ -1,0 +1,56 @@
+module BiddingsService
+  class AdminFailure
+    include Call::WithExceptionsMethods
+    include TransactionMethods
+
+    attr_accessor :event
+
+    def main_method
+      admin_failure
+    end
+
+    def call_exception
+      ActiveRecord::RecordInvalid
+    end
+
+    private
+
+    def admin_failure
+      execute_or_rollback do
+        bidding.lots.map(&:failure!)
+        recalculate_quantity!
+        bidding.failure!
+        bidding.reload
+        event_bidding_failure!
+        update_bidding_at_blockchain!
+        notify
+      end
+    end
+
+    def recalculate_quantity!
+      RecalculateQuantityService.call!(covenant: bidding.covenant)
+    end
+
+    def event_bidding_failure!
+      @event = event_service.event
+      event_service.call!
+    end
+
+    def update_bidding_at_blockchain!
+      response = Blockchain::Bidding::Update.call(bidding)
+      raise BlockchainError unless response.success?
+    end
+
+    def notify
+      Notifications::Biddings::Failure.call(bidding)
+    end
+
+    def event_service
+      @event_service ||= EventServices::Bidding::Failure.new(
+        bidding: bidding,
+        comment: comment,
+        creator: creator
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,7 @@ Rails.application.routes.draw do
       resource :reprove, module: 'biddings', only: [:update]
       resource :review, module: 'biddings', only: [:update]
       resource :force_review, module: 'biddings', only: [:update]
+      resource :fail, module: 'biddings', only: [:update]
     end
 
     resources :providers, except: [:new, :edit] do

--- a/spec/controllers/administrator/biddings/fails_controller_spec.rb
+++ b/spec/controllers/administrator/biddings/fails_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Administrator::Biddings::FailsController, type: :controller do
+  let(:covenant) { create(:covenant) }
+  let(:user) { create(:admin) }
+  let(:bidding) { create(:bidding, covenant: covenant) }
+  let(:service_response) { bidding.failure! }
+  let(:comment) { 'a comment' }
+  let(:event) do
+    create(:event_bidding_failure, eventable: bidding, creator: user)
+  end
+
+  before do
+    allow(BiddingsService::AdminFailure).to receive(:new).
+      with(bidding: bidding, creator: user, comment: comment) do
+        double('call', call: service_response, event: event)
+      end
+
+    oauth_token_sign_in user
+  end
+
+  describe '#update' do
+    let(:params) { { bidding_id: bidding, comment: comment } }
+
+    subject(:post_update) { patch :update, params: params, xhr: true }
+
+    it_behaves_like 'an admin authorization to', 'user', 'write'
+
+    it_behaves_like 'a version of', 'post_update', 'bidding'
+
+    describe 'exposes' do
+      before { post_update }
+
+      it { expect(controller.bidding).to eq bidding }
+    end
+
+    describe 'JSON' do
+      before { post_update }
+
+      context 'when updated' do
+        it { expect(response).to have_http_status :ok }
+      end
+
+      context 'when not updated' do
+        let(:service_response) { false }
+
+        it { expect(response).to have_http_status :unprocessable_entity }
+      end
+    end
+  end
+end

--- a/spec/services/biddings_service/admin_failure_spec.rb
+++ b/spec/services/biddings_service/admin_failure_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe BiddingsService::AdminFailure, type: :service do
+  let(:covenant) { create(:covenant) }
+  let(:user) { create(:admin) }
+  let(:lot) { create(:lot) }
+  let(:bidding) do
+    create(:bidding, covenant: covenant, build_lot: false, lots: [lot])
+  end
+  let(:comment) { 'a comment' }
+  let(:params) { { bidding: bidding, creator: user, comment: comment } }
+  let(:event_service_params) do
+    { bidding: bidding, comment: comment, creator: user }
+  end
+  let(:event) do
+    create(:event_bidding_failure, eventable: bidding, creator: user)
+  end
+  let(:event_response) do
+    double('event_response', call!: true, event: event)
+  end
+  let(:bc_response) { double('bc_response', success?: true) }
+
+  before do
+    allow(RecalculateQuantityService).
+      to receive(:call!).with(covenant: bidding.covenant).and_return(true)
+    allow(EventServices::Bidding::Failure).
+      to receive(:new).with(event_service_params).and_return(event_response)
+    allow(Blockchain::Bidding::Update).
+      to receive(:call).and_return(bc_response)
+    allow(Notifications::Biddings::Failure).
+      to receive(:call).with(bidding).and_return(true)
+  end
+
+  describe '#initialize' do
+    subject { described_class.new(params) }
+
+    it { expect(subject.bidding).to eq bidding }
+    it { expect(subject.creator).to eq user }
+    it { expect(subject.comment).to eq comment }
+  end
+
+  describe '.call' do
+    subject { described_class.call(params) }
+
+    context 'when success' do
+      before { subject }
+
+      it { is_expected.to be_truthy }
+      it { expect(bidding.failure?).to be_truthy }
+      it { expect(lot.failure?).to be_truthy }
+      it do
+        expect(RecalculateQuantityService).
+          to have_received(:call!).with(covenant: bidding.covenant)
+      end
+      it do
+        expect(EventServices::Bidding::Failure).
+          to have_received(:new).with(event_service_params)
+      end
+      it { expect(Blockchain::Bidding::Update).to have_received(:call) }
+      it do
+        expect(Notifications::Biddings::Failure).
+          to have_received(:call).with(bidding)
+      end
+    end
+
+    context 'when error' do
+      context 'and RecordInvalid' do
+        before do
+          allow(lot).to receive(:save!) { raise ActiveRecord::RecordInvalid }
+
+          subject
+        end
+
+        it { is_expected.to be_falsey }
+        it { expect(bidding.failure?).to be_falsey }
+        it { expect(lot.reload.failure?).to be_falsey }
+        it do
+          expect(RecalculateQuantityService).
+            not_to have_received(:call!).with(covenant: bidding.covenant)
+        end
+        it do
+          expect(EventServices::Bidding::Failure).
+            not_to have_received(:new).with(event_service_params)
+        end
+        it { expect(Blockchain::Bidding::Update).not_to have_received(:call) }
+        it do
+          expect(Notifications::Biddings::Failure).
+            not_to have_received(:call).with(bidding)
+        end
+      end
+
+      context 'and recalculate quantity error' do
+        before do
+          allow(RecalculateQuantityService).
+            to receive(:call!).with(covenant: bidding.covenant).
+            and_raise(RecalculateItemError)
+
+          subject
+        end
+
+        it { is_expected.to be_falsey }
+        it { expect(bidding.failure?).to be_falsey }
+        it { expect(lot.reload.failure?).to be_falsey }
+        it do
+          expect(EventServices::Bidding::Failure).
+            not_to have_received(:new).with(event_service_params)
+        end
+        it { expect(Blockchain::Bidding::Update).not_to have_received(:call) }
+        it do
+          expect(Notifications::Biddings::Failure).
+            not_to have_received(:call).with(bidding)
+        end
+      end
+
+      context 'and event error' do
+        before do
+          allow(EventServices::Bidding::Failure).
+            to receive(:new).with(event_service_params).
+            and_raise(ActiveRecord::RecordInvalid)
+
+          subject
+        end
+
+        it { is_expected.to be_falsey }
+        it { expect(bidding.reload.failure?).to be_falsey }
+        it { expect(lot.reload.failure?).to be_falsey }
+        it { expect(Blockchain::Bidding::Update).not_to have_received(:call) }
+        it do
+          expect(Notifications::Biddings::Failure).
+            not_to have_received(:call).with(bidding)
+        end
+      end
+
+      context 'and BlockchainError' do
+        let(:bc_response) { double('bc_response', success?: false) }
+
+        before { subject }
+
+        it { is_expected.to be_falsey }
+        it { expect(bidding.reload.failure?).to be_falsey }
+        it { expect(lot.reload.failure?).to be_falsey }
+        it do
+          expect(Notifications::Biddings::Failure).
+            not_to have_received(:call).with(bidding)
+        end
+      end
+    end
+  end
+
+  describe '.call!' do
+    it_behaves_like "Call::WithExceptionsMethods", ActiveRecord::RecordInvalid
+  end
+end


### PR DESCRIPTION
PR do frontend: https://github.com/car-bahia/sol-admin-frontend/pull/15

---

O botão de "Fracassar Lciitação", presente para o usuário Administrador Geral, não estava funcionando, pois seu mecanismo havia sido removido em Março de 2021. Este PR retorna o mecanismo original para o botão.